### PR TITLE
Allow more restrictive file permissions …

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ HISTFILE="" SATELLITE_LOGIN=mylogin SATELLITE_PASSWORD=mypass ./check_katello_
 ```
 
 ## Using an authfile
-A better possibility is to create a authfile with permisions **0600**. Just enter the username in the first line and the password in the second line and hand the path to the script:
+A better possibility is to create a authfile with permisions **0600** or **0400**. Just enter the username in the first line and the password in the second line and hand the path to the script:
 ```
 $ ./check_katello_sync.py -a giertz.auth -S giertz.stankowic.loc
 ```
@@ -51,7 +51,7 @@ The following example checks all products of an particular organization on a For
 $ ./check_katello_sync.py -s st-katello01.stankowic.loc -o Stankowic
 Satellite Username: admin
 Satellite Password:
-CRITICAL: Products outdated more than 5 days: Stankowic_Puppet, Stankowic_Docker. Products outdated up to 2 days: Stankowic_Docker. Products synchronized: owncloud-el7-x86_64, katello-client-el7-x86_64, icinga2-el7-x86_64, grafana-el7-x86_64, gitlab-ci-el7-x86_64, EPEL_7_x86_64, CentOS_7_x86_64 |
+CRITICAL: Products outdated more than 5 days: Stankowic_Puppet. Products outdated up to 2 days: Stankowic_Docker. Products synchronized: owncloud-el7-x86_64, katello-client-el7-x86_64, icinga2-el7-x86_64, grafana-el7-x86_64, gitlab-ci-el7-x86_64, EPEL_7_x86_64, CentOS_7_x86_64 |
 ```
 
 Ignoring some products synchronized manually, authentication using authfile:
@@ -99,7 +99,7 @@ object Host "st-katello01.stankowic.loc" {
   vars.katello_organization = "Stankowic"
 ```
 
-The authfile needs to have file permissions **0600** and should be owned by the ``icinga`` user:
+The authfile needs to have file permissions **0600** or **0400** and should be owned by the ``icinga`` user:
 ```
 # chmod 0600 /usr/lib64/nagios/plugins/katello.auth
 # chown icinga: /usr/lib64/nagios/plugins/katello.auth

--- a/check_katello_sync.py
+++ b/check_katello_sync.py
@@ -113,7 +113,7 @@ def check_product(product):
             PROD_CRIT.append(product["label"])
             set_code(2)
             LOGGER.debug("Critical product: '{0}'".format(product["label"]))
-        if delta.days > options.outdated_warn:
+        elif delta.days > options.outdated_warn:
             PROD_WARN.append(product["label"])
             set_code(1)
             LOGGER.debug("Warning product: '{0}'".format(product["label"]))
@@ -217,17 +217,17 @@ def get_credentials(prefix, input_file=None):
         try:
             #check filemode and read file
             filemode = oct(stat.S_IMODE(os.lstat(input_file).st_mode))
-            if filemode == "0600":
-                LOGGER.debug("File permission matches 0600")
+            if filemode == "0600" or filemode == "0400":
+                LOGGER.debug("File permission matches 0600 or 0400")
                 with open(input_file, "r") as auth_file:
                     s_username = auth_file.readline().replace("\n", "")
                     s_password = auth_file.readline().replace("\n", "")
                 return (s_username, s_password)
             else:
                 LOGGER.warning("File permissions (" + filemode + ")" \
-                    " not matching 0600!")
+                    " not matching 0600 or 0400!")
         except OSError:
-            LOGGER.warning("File non-existent or permissions not 0600!")
+            LOGGER.warning("File non-existent or permissions not 0600 or 0400!")
             LOGGER.debug("Prompting for {} login credentials as we have a" \
                 " faulty file".format(prefix))
             s_username = raw_input(prefix + " Username: ")
@@ -256,7 +256,7 @@ def parse_options(args=None):
     Login credentials are assigned using the following shell variables:
     SATELLITE_LOGIN  username
     SATELLITE_PASSWORD  password
-    It is also possible to create an authfile (permissions 0600) for usage
+    It is also possible to create an authfile (permissions 0600 or 0400) for usage
     with this script. The first line needs to contain the username, the
     second line should consist of the appropriate password. If you're not
     defining variables or an authfile you will be prompted to enter your


### PR DESCRIPTION
and make critical products not also warning.

This change allows to restrict file permissions to read-only as Icinga does not neet write-access to configuration. Furthermore critical products were also listed as warning because of the if-if-else instead of if-elif-else which is fixed in the pull request.