### PR TITLE
Refactor: Improve API request handling and output display

### DIFF
--- a/ForemanAPIClient.py
+++ b/ForemanAPIClient.py
@@ -97,7 +97,7 @@ class ForemanAPIClient:
 
 
     #TODO: find a nicer way to displaying _all_ the hits...
-    def __api_request(self, method, sub_url, payload="", hits=1337, page=1):
+    def __api_request(self, method, sub_url, payload="", params={}, hits=-1, page=1):
         """
         Sends a HTTP request to the Foreman API. This function requires
         a valid HTTP method and a sub-URL (such as /hosts). Optionally,
@@ -111,9 +111,11 @@ class ForemanAPIClient:
         :type sub_url: str
         :param payload: payload for POST/PUT requests
         :type payload: str
-        :param hits: numbers of hits/page for GET requests (must be set sadly)
+        :param params: parameters for GET request
+        :type params: dict
+        :param hits: numbers of hits/page for GET requests
         :type hits: int
-        :param page: number of page/results to display (must be set sadly)
+        :param page: number of page/results to display
         :type page: int
 
 .. todo:: Find a nicer way to display all hits, we shouldn't use 1337 hits/page
@@ -135,6 +137,12 @@ class ForemanAPIClient:
                 #add special headers for non-GETs
                 my_headers["Content-Type"] = "application/json"
                 my_headers["Accept"] = "application/json,version=2"
+
+            if hits > 0:
+                params["per_page"] = hits
+                params["page"] = page
+            else: 
+                params['full_result'] = 'true'
 
             #send request
             if method.lower() == "put":
@@ -158,9 +166,8 @@ class ForemanAPIClient:
             else:
                 #GET
                 result = self.SESSION.get(
-                    "{}{}?per_page={}&page={}".format(
-                        self.URL, sub_url, hits, page),
-                    headers=self.HEADERS, verify=self.VERIFY
+                    "{}{}".format(self.URL, sub_url),
+                    headers=self.HEADERS, verify=self.VERIFY, params=params
                 )
             if "unable to authenticate" in result.text.lower():
                 raise ValueError("Unable to authenticate")
@@ -179,7 +186,7 @@ class ForemanAPIClient:
             pass
 
     #Aliases
-    def api_get(self, sub_url, hits=1337, page=1):
+    def api_get(self, sub_url, params={}, hits=-1, page=1):
         """
         Sends a GET request to the Foreman API. This function requires a
         sub-URL (such as /hosts) and - optionally - hits/page and page
@@ -187,12 +194,14 @@ class ForemanAPIClient:
 
         :param sub_url: relative path within the API tree (e.g. /hosts)
         :type sub_url: str
+        :param params: parameters for GET request
+        :type params: dict 
         :param hits: numbers of hits/page for GET requests (must be set sadly)
         :type hits: int
         :param page: number of page/results to display (must be set sadly)
         :type page: int
         """
-        return self.__api_request("get", sub_url, "", hits, page)
+        return self.__api_request("get", sub_url, payload="", params=params, hits=hits, page=page)
 
     def api_post(self, sub_url, payload):
         """

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ ./check_katello_sync.py -a giertz.auth -s giertz.stankowic.loc
 ```
 
 # Requirements
-The plugin requires Python 2.6 or newer - it also requires the `requests` and `simplejson` modules.
+The plugin requires Python 3.6 or newer - it also requires the `requests` and `simplejson` modules.
 The plugin requires API version 2 - the script checks the API version and aborts if you are using a historic version of Foreman/Katello.
 
 # Usage

--- a/check_katello_sync.py
+++ b/check_katello_sync.py
@@ -198,7 +198,10 @@ def check_products():
     # final string
     output = f"{str_crit}{str_warn}{str_ok} {perfdata} "
     # print result and die in a fire
-    print(f"{get_return_str()}: {output}")
+    if options.short_output or (options.short_ok_output and not STATE):
+        print(get_return_str())
+    else:
+        print(f"{get_return_str()}: {output}")
     sys.exit(STATE)
 
 
@@ -288,6 +291,15 @@ def parse_options(args=None):
     gen_opts.add_argument("-P", "--show-perfdata", dest="show_perfdata", \
     default=False, action="store_true", \
     help="enables performance data (default: no)")
+    # -S / --short
+    gen_opts.add_argument("-S", "--short", dest="short_output", \
+    default=False, action="store_true", \
+    help="only outputs status (default: no)")
+    # --short-ok
+    gen_opts.add_argument("--short-ok", dest="short_ok_output", \
+    default=False, action="store_true", \
+    help="only outputs products if any are not ok (default: no)"
+    )
 
     # FOREMAN ARGUMENTS
     # -a / --authfile

--- a/check_katello_sync.py
+++ b/check_katello_sync.py
@@ -137,9 +137,10 @@ def check_products():
     global PROD_TOTAL
 
     # get API result
+    api_params = {"organization_id": options.org}
     result_obj = json.loads(
         FOREMAN_CLIENT.api_get(
-            f"/products?organization_id={options.org}&per_page=1337"
+            "/products", params=api_params
         )
     )
 


### PR DESCRIPTION
Here are the key changes:

1. Refactor the `__api_request` method to replace the `hits` argument with `params` (a dictionary), allowing for more flexible API requests. The `hits` argument was previously used to control the number of hits per page for GET requests, but this was not an ideal solution. The new `params` argument will allow for more control over GET requests.
2. Update the way hits are handled in GET requests. Previously, a fixed number of hits per page (1337) was used for all GET requests. Now, if `hits` is greater than 0, `params["per_page"]` and `params["page"]` are set accordingly. If `hits` is not greater than 0, `params['full_result']` is set to 'true', which should return all results.
3. Update the `api_get` method to accept the new `params` argument and pass it to the `__api_request` method.
4. Refactor the `check_products` function to use the new `params` argument when making GET requests via the `api_get` method. The `params` dictionary is used to pass the `organization_id` to the API.
5. Add new command-line options `-S` and `--short-ok` to control the output display. If `-S` is used, only the status is output. If `--short-ok` is used, products are only output if any are not ok.
6. Update the `check_products` method to respect the new `-S` and `--short-ok` options when displaying output.
7.  Switch to [fnmatch](https://docs.python.org/3/library/fnmatch.html) based pattern matching in include and exclude to reduce the number of products that have to be listed

## Files Changed
- `ForemanAPIClient.py`
- `main.py`
- `README.md`