### PR TITLE
Changed wrong function for FQDN determination: socket.gethostbyaddr -…

### DIFF
--- a/ForemanAPIClient.py
+++ b/ForemanAPIClient.py
@@ -271,7 +271,7 @@ class ForemanAPIClient:
             hostname = socket.gethostname()
         else:
             #convert to FQDN if possible:
-            fqdn = socket.gethostbyaddr(hostname)
+            fqdn = socket.gethostbyname_ex(hostname)
             if "." in fqdn[0]:
                 hostname = fqdn[0]
         return hostname


### PR DESCRIPTION
The socket.gethostbyaddr() function normally expects an IP address as an argument, not a hostname. Passing a hostname may result in an error. If you want to retrieve the FQDN of a hostname instead, you should use socket.gethostbyname_ex(hostname) directly.

The incorrect function also throws an error on Python 3.9, hence I create a bugfix.